### PR TITLE
BUG/MINOR: tests: fix namespace getter logic

### DIFF
--- a/test/integration/utils/utils.go
+++ b/test/integration/utils/utils.go
@@ -32,7 +32,7 @@ func GetIntTestNamespace() (string, error) {
 	}
 	dir = filepath.Base(dir)
 	dir = strings.Map(func(r rune) rune {
-		if r < 'a' || r > 'z' && r != '-' {
+		if (r < 'a' || r > 'z') && r != '-' {
 			return '-'
 		}
 		return r


### PR DESCRIPTION
You need brackets here `if (r < 'a' || r > 'z') && r != '-'`  because `bool || bool && bool` == `bool || (bool && bool)` and as such we are basically ignoring `r != '-'`.

Proof:
```
func main() {
	r := '-'
	if r < 'a' || r > 'z' && r != '-' {
		fmt.Println("SHOULD NOT RUN")
	}
}
```