### PR TITLE
BUG/MEDIUM: ci: use pebble fork in CI builds

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -20,8 +20,11 @@ COPY /go.mod /src/go.mod
 COPY /go.sum /src/go.sum
 RUN cd /src && go mod download
 
-RUN go install github.com/canonical/pebble/cmd/pebble@v1.25.0
-
+# https://github.com/canonical/pebble/issues/719
+# RUN go install github.com/canonical/pebble/cmd/pebble@v1.25.0
+WORKDIR /src
+RUN git clone --branch stop-signal --single-branch https://github.com/haproxytech/pebble.git
+RUN cd pebble/cmd/pebble && go build -buildvcs=true -o /go/bin/pebble
 COPY / /src
 
 RUN mkdir -p /var/run/vars && \


### PR DESCRIPTION
https://github.com/haproxytech/haproxy-unified-gateway/commit/428ca4cede2757c1d3c1c3f6ece8827d3e177df8 introduced pebble configuration that is only valid for the pebble fork.  It also changed the dev dockerfile, but not the dockerfile used in CI.  This causes nightly images to fail to start with default configuration.

This change addresses that by using the pebble fork in CI dockerfile as well.

Verified in a local deployment that it works.

@oktalz tagging you because you made the original pebble change.