### PR TITLE
BUG/MINOR: update predicate in controller registration

### DIFF
--- a/k8s/gate/controller.go
+++ b/k8s/gate/controller.go
@@ -372,7 +372,7 @@ func registerControllers(ctx context.Context, extractGVK utilsk8s.ExtractGVK, cf
 			options: []Option{
 				WithK8sPredicate(
 					k8spredicate.And(
-						k8spredicate.GenerationChangedPredicate{},
+						k8spredicate.ResourceVersionChangedPredicate{},
 						predicate.NewNamespacePredicate(cfg.Namespaces),
 					),
 				),


### PR DESCRIPTION
Replaced `GenerationChangedPredicate` with `ResourceVersionChangedPredicate` in the controller registration logic to improve resource tracking, since I observed cases where services targeting multiple ports were left empty of servers for the [2..N] backends/ports until next batch.

Fixes #11